### PR TITLE
Fix incorrect format description in docs

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -172,7 +172,7 @@ Because Luxon was able to parse the string without difficulty, the output is a l
 | mm              |              | minute, padded to 2                                            |                        07 |
 | h               |              | hour in 12-hour time, no padding                               |                         1 |
 | hh              |              | hour in 12-hour time, padded to 2                              |                        01 |
-| H               |              | hour in 24-hour time, padded to 2                              |                         9 |
+| H               |              | hour in 24-hour time, no padding                               |                         9 |
 | HH              |              | hour in 24-hour time, padded to 2                              |                        13 |
 | Z               |              | narrow offset                                                  |                        +5 |
 | ZZ              |              | short offset                                                   |                    +05:00 |


### PR DESCRIPTION
Noticed this incorrect description while reading into Luxon.